### PR TITLE
feat: add AIRanked to SEO tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -992,6 +992,7 @@ Use these hashtags in search to filter out the tools
 ## SEO
 
 - [Adaptify](https://www.adaptify.ai/) - Empower Business Success with AI-Powered ChatGPT `#paid`
+- [AIRanked](https://geochecktool.com/) - Free AI visibility checker for tracking brand mentions across ChatGPT, Perplexity, and Google AI Overview. `#free` `#seo`
 - [AutoBlogging Pro](https://autoblogging.pro/) - AI-Powered Content Automation for WordPress Blogs `#freemium`
 - [Frase](https://www.frase.io/) - Content optimization tool that helps businesses create SEO-friendly content quickly and easily. `#paid`
 - [Frizerly](https://www.thefrizerly.com/) - AI agent that learns your business and competitors to automatically publish SEO blogs. `#paid`


### PR DESCRIPTION
Adds AIRanked to the SEO category.\n\nAIRanked is a free AI visibility checker for tracking brand mentions across ChatGPT, Perplexity, and Google AI Overview. I am connected to this tool and am submitting it for review.