### PR TITLE
Add LandscapioAI

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,6 +364,7 @@ Use these hashtags in search to filter out the tools
 - [Galileo AI](https://www.usegalileo.ai/explore) -Galileo AI is a UI generation platform for easy and fast design ideation.Generative AI for user interface design, empowering you to design beyond imagination with speed . `#freemium`
 - [GitMind](https://gitmind.com/) - Brainstorming and architecture diagram creation. `#free`
 - [Kittl](https://www.kittl.com/) - AI-powered graphic design tool with text-to-image and logo generation. `#freemium`
+- [LandscapioAI](https://www.landscapioai.com/) - AI landscape design generator that turns yard photos into outdoor redesign concepts and cost estimates. `#freemium`
 - [LogoAi](https://www.logoai.com/logo-maker) - AI-powered logo maker and online design tool. `#freemium`
 - [Looka](https://looka.com/) - Use Looka's AI-powered platform to design a logo and build a brand you love. `#free`
 - [Miaoban Board](https://miaoban.com/) - Online space for graphic drawing and brainstorming. `#free`


### PR DESCRIPTION
Adds LandscapioAI (https://www.landscapioai.com/) to the relevant AI design/image tools section.

LandscapioAI is an AI landscape design generator that turns yard photos into outdoor redesign concepts and cost estimates. It has free daily use and no credit card requirement for the free entry path.

Checked before submitting:
- Existing list did not mention LandscapioAI or landscapioai.com
- No existing GitHub issues/PRs in this repo for LandscapioAI
- Patch is a minimal directory-native addition