### PR TITLE
Add Punch Needle Generator to Image Generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -725,6 +725,7 @@ Use these hashtags in search to filter out the tools
 - [pica-ai](https://www.pica-ai.com/) - Experience funny or realistic face swapping effects. Begin by uploading your photo!. `#freemium`
 - [Picsart](https://picsart.com/ai-image-generator/) - Convert words into an image in mere seconds with the Picsart AI Image Generator. `#freemium`
 - [Playground AI](https://playground.com/) - Free-to-use online tool to create art, social media posts, presentations, posters, videos, logos and more. `#free`
+- [Punch Needle Generator](https://www.punchneedle.co.il/en) - AI-generated punch needle embroidery patterns with color-coded yarn maps from text prompts or image uploads. `#freemium` `#design`
 - [Remaker-Ai](https://remaker.ai/en) - All-in-one tool leveraging the capabilities of artificial intelligence. Craft and produce diverse content formats, spanning text, images, and beyond. `#free`
 - [removebg](https://remove.bg/) - Remove any Image Background `#free`
 - [Rentoor](https://rentoor.vercel.app) - Enhance your images with Rentoor's super-resolution feature, restoring clarity and detail for stunning visuals. `#freemium`


### PR DESCRIPTION
Adds Punch Needle Generator under **Image Generator**, inserted alphabetically between Playground AI and Remaker-Ai.

- **Name:** Punch Needle Generator
- **URL:** https://www.punchneedle.co.il/en
- **Description:** AI-generated punch needle embroidery patterns with color-coded yarn maps from text prompts or image uploads.
- **Tags:** `#freemium` `#design`

Per CONTRIBUTING:
- Format: `- [Name](url) - Description. \`#tag\``
- Kept alphabetized within the category.
- Direct link to the tool, no marketing language.
- I'm the maintainer of the tool.