### PR TITLE
fix: make prebuild README copy cross-platform

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   ],
   "scripts": {
     "dev": "vite",
-    "prebuild": "cp README.md public/",
+    "prebuild": "node scripts/copy-readme.mjs",
     "build": "vite build",
     "preview": "vite preview",
     "type-check": "tsc --noEmit",

--- a/scripts/copy-readme.mjs
+++ b/scripts/copy-readme.mjs
@@ -1,0 +1,8 @@
+import { copyFile, mkdir } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+
+const source = resolve('README.md');
+const destination = resolve('public', 'README.md');
+
+await mkdir(dirname(destination), { recursive: true });
+await copyFile(source, destination);


### PR DESCRIPTION
## Summary

- replace the Unix-only `cp README.md public/` prebuild command with a small Node script
- keep the existing README copy behavior without adding a new dependency
- unblock `pnpm run build` on Windows shells

## Verification

- `pnpm run build`
- `pnpm run type-check`
- `pnpm run test -- --run`

## Notes

This PR intentionally does not touch the existing lint baseline from #221. It only fixes the cross-platform prebuild failure.

The Vercel check currently reports a GitHub/Vercel authorization failure link rather than a project build log. Local production build passes on Windows after this change.

Refs #221.