### PR TITLE
Potential fix for code scanning alert no. 8: Incomplete URL substring sanitization

### DIFF
--- a/src/components/MCPServerDetail.tsx
+++ b/src/components/MCPServerDetail.tsx
@@ -227,7 +227,17 @@ const MCPServerDetail: React.FC = () => {
                 const serverData = response.data[0];
                 setServer(serverData);
                 
-                if (serverData.githubUrl && serverData.githubUrl.includes('github.com')) {
+                if (
+                    serverData.githubUrl &&
+                    (() => {
+                        try {
+                            const host = new URL(serverData.githubUrl).hostname.toLowerCase();
+                            return host === 'github.com' || host.endsWith('.github.com');
+                        } catch {
+                            return false;
+                        }
+                    })()
+                ) {
                     fetchGithubData(serverData.githubUrl);
                 }
             } else {


### PR DESCRIPTION
Potential fix for [https://github.com/Hyraze/collective-ai-tools/security/code-scanning/8](https://github.com/Hyraze/collective-ai-tools/security/code-scanning/8)

The correct fix is to parse the URL with the built-in `URL` constructor and validate the `hostname` explicitly, rather than searching the full string.  
For this case, preserve current behavior intent (“GitHub URLs only”) by allowing `github.com` and legitimate GitHub subdomains via exact/suffix host checks.

In `src/components/MCPServerDetail.tsx`, update the line-230 conditional so it:

1. Ensures `serverData.githubUrl` exists.
2. Parses it safely in a small inline function/IIFE with `try/catch`.
3. Compares `hostname.toLowerCase()` against:
   - exact `github.com`, or
   - `.endsWith('.github.com')` for subdomains.
4. Returns `false` on parse failure.

No new imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
