### PR TITLE
Potential fix for code scanning alert no. 7: Clear text storage of sensitive information

### DIFF
--- a/src/lib/llmService.ts
+++ b/src/lib/llmService.ts
@@ -65,12 +65,22 @@ const GeminiModelSchema = z.object({
 export const LLMService = {
   getConfig(): LLMConfig {
     const stored = localStorage.getItem(STORAGE_KEY);
-    if (stored) return JSON.parse(stored);
+    if (stored) {
+      const parsed = JSON.parse(stored) as LLMConfig;
+      return {
+        ...parsed,
+        // Never hydrate persisted secrets from storage.
+        apiKey: '',
+        keys: undefined
+      };
+    }
     return { provider: 'openai', apiKey: '', model: 'gpt-4o', baseUrl: 'https://api.openai.com/v1' };
   },
 
   saveConfig(config: LLMConfig) {
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(config));
+    const { apiKey: _apiKey, keys: _keys, ...safeConfig } = config;
+    // Persist only non-sensitive preferences.
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(safeConfig));
   },
 
   async streamCompletion(


### PR DESCRIPTION
Potential fix for [https://github.com/Hyraze/collective-ai-tools/security/code-scanning/7](https://github.com/Hyraze/collective-ai-tools/security/code-scanning/7)

General fix: do not store API secrets (`apiKey`, `keys.*`) in `localStorage`. Persist only non-sensitive preferences (provider/baseUrl/model). Keep keys only in memory for the active session/UI state.

Best minimal fix without changing core functionality flow:
- In `src/lib/llmService.ts`, sanitize config before persistence in `saveConfig` by stripping sensitive fields.
- In `getConfig`, defensively clear any legacy stored sensitive fields when loading old entries so previously persisted keys are no longer rehydrated.
- Keep method signatures unchanged so callers in `PatternStudio.tsx` and `AIConfigPanel.tsx` continue to work without edits.

This single-file change addresses all 6 variants because every flow ends at `LLMService.saveConfig(...)`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
