### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Test


### PR DESCRIPTION
Potential fix for [https://github.com/Hyraze/collective-ai-tools/security/code-scanning/6](https://github.com/Hyraze/collective-ai-tools/security/code-scanning/6)

Add an explicit `permissions` block to the workflow so all jobs inherit least-privilege token access.  
Best fix here: define at the workflow root (after `on:` and before `jobs:`) with:

- `contents: read`

This is sufficient for `actions/checkout@v4` and does not alter workflow logic. No new methods/imports/dependencies are needed.  
Edit file: `.github/workflows/ci.yml`, inserting the permissions block between the trigger section and `jobs:`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
