### PR TITLE
feat: add Machi Photos to Image Editing

### DIFF
--- a/README.md
+++ b/README.md
@@ -708,6 +708,7 @@ Use these hashtags in search to filter out the tools
 - [Img.Upscaler](https://imgupscaler.com/) - Img.Upscaler uses AI to enlarge your jpg, png, webp images by 200% or 400% without losing quality. `#freemium`
 - [Leonardo.ai](https://leonardo.ai/) - Generative platform with Veo 3 and Phoenix. `#free`
 - [LiblibAI](https://www.liblib.art/) - LoRA model training and online generation. `#free`
+- [Machi Photos](https://machiphotos.com/create) - Browser-based ID photo maker for compliant crops, AI background replacement, retouching, and convenience-store print sheets. `#freemium`
 - [Meshy](https://www.meshy.ai/) - Convert text/images to 3D mesh models. ``
 - [Midjourney](https://www.midjourney.com/) - Gold standard for high-fidelity visual art. `#paid`
 - [Nano Banana](https://nanobanana.im/) - Transform any image with simple text prompts. Nano-banana's advanced model delivers consistent character editing and scene preservation that surpasses Flux Kontext. Experience the future of AI image editing. `#freemium`


### PR DESCRIPTION
## Summary
- Add Machi Photos to the Image Editing category.
- Link directly to the browser-based ID photo creator at https://machiphotos.com/create.

## Why it fits
Machi Photos helps users create compliant ID photo crops, use AI background replacement and retouching, and export convenience-store print sheets from the browser.

## Checklist
- [x] Added the tool to README.md
- [x] Kept the Image Editing list alphabetized
- [x] Included a concise description and tag
