### PR TITLE
Add Voqusa to Audio & Speech

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ Use these hashtags in search to filter out the tools
 - [PodPilot](https://www.podpilot.ai/) - PodPilot is an AI tool designed to simplify the process of creating high-quality podcast series for organizations `#paid`
 - [VideoDubber](https://videodubber.ai) - Offers free video translation, dubbing,  cloning, and text-to-speech services. `#freemium`
 - [VideoToBlog](https://www.videotoblog.ai/) - Convert YouTube videos to blog content in one click `#free`
+- [Voqusa](https://www.voqusa.com/) - Turns TikTok, YouTube, Instagram and other social videos into accurate transcripts and subtitles in seconds, no signup required. `#freemium` `#transcription`
 
 **[⬆️ Back to Top](#table-of-contents)**
 


### PR DESCRIPTION
Adds [Voqusa](https://www.voqusa.com/) to the **Audio & Speech** category (alphabetical, after VideoToBlog).

Voqusa is a free AI transcript/subtitle generator for social videos — paste a TikTok, YouTube, Instagram, Facebook, X, LinkedIn or Pinterest URL and get an accurate transcript (SRT/VTT/TXT) in 14+ languages, no signup required.

- [x] Read CONTRIBUTING.md
- [x] Added in correct category, alphabetized
- [x] Concise description with tags