### PR TITLE
Add igly.ai to image editing tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -705,6 +705,7 @@ Use these hashtags in search to filter out the tools
 - [BulkPicTools](https://bulkpictools.com/) - Free browser-based bulk image workspace. Upload once, chain 40+ tools (compress, convert, crop, background removal, face blur) without re-uploading. Files never leave your device. `#free`
 - [Cutout.Pro](https://www.cutout.pro/) - Creative visual platform and automated tasks. `#free`
 - [Image Candy](https://imagecandy.com/) - Online Image Editor - Image Candy `#free`
+- [igly.ai](https://igly.ai/) - Browser-based AI image editor for background removal, inpainting, upscaling, and generative fill. `#freemium`
 - [Img.Upscaler](https://imgupscaler.com/) - Img.Upscaler uses AI to enlarge your jpg, png, webp images by 200% or 400% without losing quality. `#freemium`
 - [Leonardo.ai](https://leonardo.ai/) - Generative platform with Veo 3 and Phoenix. `#free`
 - [LiblibAI](https://www.liblib.art/) - LoRA model training and online generation. `#free`


### PR DESCRIPTION
## Summary
- Add igly.ai to the Image Editing section.
- Keep the entry format consistent with the surrounding list.

## Why
igly.ai is a browser-based AI image editor covering background removal, inpainting, upscaling, and generative fill, which fits the existing Image Editing category alongside tools like Photoroom and remove.bg.

Demo/reference: https://www.youtube.com/watch?v=HB2E1WZ12is