### PR TITLE
feat: Add MonkeyEatingMango to Travel

### DIFF
--- a/README.md
+++ b/README.md
@@ -1096,6 +1096,7 @@ Use these hashtags in search to filter out the tools
 ## Travel
 
 - [Famxplor](https://famxplor.com/) - Find activities for your family vacations worldwide. `#paid`
+- [MonkeyEatingMango](https://monkeyeatingmango.com/) - Your complete trip, planned in minutes with routes, attractions, budgets, and food guide. `#free`
 - [PLAN by Ixigo](https://www.ixigo.com/) - Your AI-Powered Travel Planning Companion `#free`
 - [Roam Around](https://www.roamaround.io/) - Find interesting and fun places to visit `#free`
 - [Travelnaut](https://travelnaut.com/) - Find travel information on attractions, food, culture, and more in one place to prepare the next trip of your dreams `#free`

--- a/public/README.md
+++ b/public/README.md
@@ -1052,6 +1052,7 @@ Use these hashtags in search to filter out the tools
 ## Travel
 
 - [Famxplor](https://famxplor.com/) - Find activities for your family vacations worldwide. `#paid`
+- [MonkeyEatingMango](https://monkeyeatingmango.com/) - Your complete trip, planned in minutes with routes, attractions, budgets, and food guide. `#free`
 - [PLAN by Ixigo](https://www.ixigo.com/) - Your AI-Powered Travel Planning Companion `#free`
 - [Roam Around](https://www.roamaround.io/) - Find interesting and fun places to visit `#free`
 - [Travelnaut](https://travelnaut.com/) - Find travel information on attractions, food, culture, and more in one place to prepare the next trip of your dreams `#free`


### PR DESCRIPTION
## Description

Adds MonkeyEatingMango (https://monkeyeatingmango.com/) to the Travel category. It is a unified AI travel planner that starts with recommending destinations to finally providing the comprehensive plan including budget, routes, attractions and food guide. It works with asking a few click based questions and does not need text input. #free. 

## Checklist

Before submitting this pull request, please ensure that you have done the following:

- [x] Read and understood the [Contributing Guidelines](CONTRIBUTING.md).
- [x] Checked that your changes align with the repository's goals and content.
- [x] The submission is not already present in the list

## Related Issues

N/A

## Additional Notes (if applicable)

Only README.md was modified, with a single new line added under the Travel section.

---

By submitting this pull request, you confirm that you have read and agree to abide by the [Code of Conduct](CODE_OF_CONDUCT.md) and the [Contributing Guidelines](CONTRIBUTING.md) of the AI Tools Collective project.
