### PR TITLE
Customer Support: add Hellomatik (AI agents across WhatsApp, email, web)

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,8 +299,8 @@ Use these hashtags in search to filter out the tools
 
 ## Customer Support
 
+- [Hellomatik](https://hellomatik.com) - AI agent platform that turns company knowledge into agents that answer, sell and book across WhatsApp, email and web. `#paid`
 - [Tongyi Xiaomi](https://tongyi.aliyun.com/) - Outbound calling and dialogue robots for business. ``
-- [Hellomatik](https://hellomatik.com) - AI agent platform that turns company knowledge into agents that answer, sell and book across WhatsApp, email and web.
 
 **[⬆️ Back to Top](#table-of-contents)**
 

--- a/README.md
+++ b/README.md
@@ -300,6 +300,7 @@ Use these hashtags in search to filter out the tools
 ## Customer Support
 
 - [Tongyi Xiaomi](https://tongyi.aliyun.com/) - Outbound calling and dialogue robots for business. ``
+- [Hellomatik](https://hellomatik.com) - AI agent platform that turns company knowledge into agents that answer, sell and book across WhatsApp, email and web.
 
 **[⬆️ Back to Top](#table-of-contents)**
 


### PR DESCRIPTION
Adds **Hellomatik** to the **Customer Support** category, in alphabetical order and with the `#paid` pricing tag, per CONTRIBUTING (README is the source of truth for collectiveai.tools). Hellomatik turns a company's own knowledge into agents that answer, book and sell across WhatsApp, email and web. Single-line addition. Thanks for maintaining the list!