### PR TITLE
test: add unit tests for api.ts covering fetchWithRetry backoff logic

### DIFF
--- a/src/lib/__tests__/api.test.ts
+++ b/src/lib/__tests__/api.test.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { fetchFilters, fetchMCPServers, fetchAITools } from '../api';
+
+const fetchMock = vi.mocked(fetch);
+
+function mockResponse(
+  body: unknown = null,
+  init: { status?: number; headers?: Record<string, string> } = {},
+): Response {
+  const status = init.status ?? 200;
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    headers: new Headers(init.headers),
+    json: () => Promise.resolve(body),
+  } as Response;
+}
+
+const filtersBody = { categories: [], languages: [], pricing: [] };
+const listBody = { data: [], pagination: { total: 0, page: 1, limit: 10, totalPages: 0 } };
+
+describe('api', () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    warnSpy.mockRestore();
+  });
+
+  describe('successful responses', () => {
+    it('returns parsed JSON from fetchFilters', async () => {
+      fetchMock.mockResolvedValue(mockResponse(filtersBody));
+
+      await expect(fetchFilters()).resolves.toEqual(filtersBody);
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(fetchMock).toHaveBeenCalledWith('/api/filters', {});
+    });
+
+    it('builds the MCP query string from provided params only', async () => {
+      fetchMock.mockResolvedValue(mockResponse(listBody));
+
+      await fetchMCPServers({
+        page: 2,
+        limit: 10,
+        search: 'claude',
+        type: 'server',
+        category: 'dev-tools',
+        language: 'typescript',
+        id: 'my-server',
+        sort: 'stars',
+      });
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/mcp?page=2&limit=10&search=claude&type=server&category=dev-tools&language=typescript&id=my-server&sort=stars',
+        {},
+      );
+
+      await fetchMCPServers({});
+      expect(fetchMock).toHaveBeenLastCalledWith('/api/mcp?', {});
+    });
+
+    it('builds the AI tools query string from provided params only', async () => {
+      fetchMock.mockResolvedValue(mockResponse(listBody));
+
+      await fetchAITools({ page: 1, limit: 20, search: 'agent', category: 'chat', pricing: 'free', sort: 'newest' });
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/ai-tools?page=1&limit=20&search=agent&category=chat&pricing=free&sort=newest',
+        {},
+      );
+
+      await fetchAITools({});
+      expect(fetchMock).toHaveBeenLastCalledWith('/api/ai-tools?', {});
+    });
+  });
+
+  describe('retry on 429/5xx', () => {
+    it('retries after the backoff delay on 500 and resolves on success', async () => {
+      fetchMock
+        .mockResolvedValueOnce(mockResponse(null, { status: 500 }))
+        .mockResolvedValueOnce(mockResponse(filtersBody));
+
+      const promise = fetchFilters();
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+
+      await vi.advanceTimersByTimeAsync(999);
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+
+      await vi.advanceTimersByTimeAsync(1);
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+
+      await expect(promise).resolves.toEqual(filtersBody);
+    });
+
+    it('waits for the Retry-After header (seconds) on 429 instead of the backoff', async () => {
+      fetchMock
+        .mockResolvedValueOnce(mockResponse(null, { status: 429, headers: { 'Retry-After': '2' } }))
+        .mockResolvedValueOnce(mockResponse(filtersBody));
+
+      const promise = fetchFilters();
+
+      // Past the default 1000ms backoff, but before the 2s Retry-After
+      await vi.advanceTimersByTimeAsync(1999);
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+
+      await vi.advanceTimersByTimeAsync(1);
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+
+      await expect(promise).resolves.toEqual(filtersBody);
+    });
+
+    it('doubles the backoff on each retry (1s, 2s, 4s)', async () => {
+      fetchMock.mockResolvedValue(mockResponse(null, { status: 500 }));
+
+      const promise = fetchFilters();
+      const assertion = expect(promise).rejects.toThrow('Failed to fetch filters');
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+
+      await vi.advanceTimersByTimeAsync(1000);
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+
+      await vi.advanceTimersByTimeAsync(2000);
+      expect(fetchMock).toHaveBeenCalledTimes(3);
+
+      await vi.advanceTimersByTimeAsync(4000);
+      expect(fetchMock).toHaveBeenCalledTimes(4);
+
+      await assertion;
+    });
+
+    it('gives up after retries are exhausted and the caller throws', async () => {
+      fetchMock.mockResolvedValue(mockResponse(null, { status: 503 }));
+
+      const promise = fetchMCPServers({});
+      const assertion = expect(promise).rejects.toThrow('Failed to fetch MCP data');
+
+      await vi.runAllTimersAsync();
+      await assertion;
+      expect(fetchMock).toHaveBeenCalledTimes(4);
+    });
+
+    it('does not retry non-retryable errors like 404', async () => {
+      fetchMock.mockResolvedValue(mockResponse(null, { status: 404 }));
+
+      await expect(fetchAITools({})).rejects.toThrow('Failed to fetch AI tools');
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('network errors', () => {
+    it('retries a network error and resolves on success', async () => {
+      fetchMock
+        .mockRejectedValueOnce(new TypeError('Failed to fetch'))
+        .mockResolvedValueOnce(mockResponse(filtersBody));
+
+      const promise = fetchFilters();
+      await vi.advanceTimersByTimeAsync(1000);
+
+      await expect(promise).resolves.toEqual(filtersBody);
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+
+    it('rethrows the network error once retries are exhausted', async () => {
+      fetchMock.mockRejectedValue(new TypeError('Failed to fetch'));
+
+      const promise = fetchFilters();
+      const assertion = expect(promise).rejects.toThrow('Failed to fetch');
+
+      await vi.runAllTimersAsync();
+      await assertion;
+      expect(fetchMock).toHaveBeenCalledTimes(4);
+    });
+  });
+});


### PR DESCRIPTION
## Description

Closes #275

Adds unit tests for `src/lib/api.ts`, which previously had 0% coverage. One new file (`src/lib/__tests__/api.test.ts`, 10 tests) — no production code changed.

## What's covered

- **Successful responses** — `fetchFilters` returns parsed JSON; `fetchMCPServers` / `fetchAITools` build query strings correctly from provided params (all params exercised, plus the empty-params case)
- **Retry on 429/5xx** — retries a 500 after exactly the 1000ms backoff (asserted it does *not* fire at 999ms), honors `Retry-After: 2` on a 429 (waits 2000ms instead of the backoff), and doubles the backoff 1s → 2s → 4s across attempts
- **Giving up** — persistent 5xx exhausts 3 retries (4 fetch calls total), after which the caller throws its specific error; a 404 is *not* retried
- **Network errors** — a rejected `fetch` is retried and can recover; once retries are exhausted the original error propagates

## Approach

- Uses the `global.fetch = vi.fn()` stub already set up in `test/setup.ts` rather than MSW — the test setup has no `msw/node` server wired up, and the global stub would bypass it anyway
- Fake timers (`vi.advanceTimersByTimeAsync`) so backoff waits run instantly; retry `console.warn` noise silenced with a spy
## Checklist

Before submitting this pull request, please ensure that you have done the following:

- [x] Read and understood the [Contributing Guidelines](CONTRIBUTING.md).
- [x] Checked that your changes align with the repository's goals and content.
- [x] The submission is not already present in the list

## Related Issues

If this pull request resolves or is related to any issues, please mention them here using the following format: "Fixes #123" or "Relates to #456."

## Additional Notes (if applicable)

<img width="767" height="158" alt="image" src="https://github.com/user-attachments/assets/b8d8d953-7b8a-498b-8d9f-81ca9434deec" />

<img width="839" height="373" alt="image" src="https://github.com/user-attachments/assets/c5c05341-b8ea-4d6f-8bd3-f5dadf5dc3ff" />

---

By submitting this pull request, you confirm that you have read and agree to abide by the [Code of Conduct](CODE_OF_CONDUCT.md) and the [Contributing Guidelines](CONTRIBUTING.md) of the AI Tools Collective project.
