### PR TITLE
test(security): cover security utilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,7 +105,8 @@
   "pnpm": {
     "overrides": {
       "tar": ">=7.5.3",
-      "undici": ">=5.28.5"
+      "undici": ">=5.28.5",
+      "jsdom>undici": "^7.20.0"
     }
   },
   "msw": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,7 @@ settings:
 overrides:
   tar: '>=7.5.3'
   undici: '>=5.28.5'
+  jsdom>undici: ^7.20.0
 
 importers:
 
@@ -4606,6 +4607,10 @@ packages:
     resolution: {integrity: sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==}
     engines: {node: '>=14.0'}
 
+  undici@7.29.0:
+    resolution: {integrity: sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==}
+    engines: {node: '>=20.18.1'}
+
   unicode-canonical-property-names-ecmascript@2.0.1:
     resolution: {integrity: sha512-dA8WbNeb2a6oQzAQ55YlT5vQAWGV9WXOsi3SskE3bcCdM0P4SDd+24zS/OCacdRq5BkdsRj9q3Pg6YyQoxIGqg==}
     engines: {node: '>=4'}
@@ -8589,7 +8594,7 @@ snapshots:
       saxes: 6.0.0
       symbol-tree: 3.2.4
       tough-cookie: 6.0.0
-      undici: 5.29.0
+      undici: 7.29.0
       w3c-xmlserializer: 5.0.0
       webidl-conversions: 8.0.1
       whatwg-mimetype: 5.0.0
@@ -10177,6 +10182,8 @@ snapshots:
   undici@5.29.0:
     dependencies:
       '@fastify/busboy': 2.1.1
+
+  undici@7.29.0: {}
 
   unicode-canonical-property-names-ecmascript@2.0.1: {}
 

--- a/src/lib/__tests__/security.test.ts
+++ b/src/lib/__tests__/security.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it } from 'vitest';
+import {
+  escapeHtml,
+  getCSPDirectives,
+  sanitizeHtml,
+  sanitizeUrl,
+  validateTool,
+} from '../security';
+
+describe('security', () => {
+  describe('sanitizeHtml', () => {
+    it('preserves allowed formatting and link attributes', () => {
+      const html =
+        '<p class="intro"><strong>Hello</strong><br><a href="https://example.com/docs" target="_blank" rel="noopener">Docs</a></p>';
+
+      expect(sanitizeHtml(html)).toBe(html);
+    });
+
+    it('removes executable elements and disallowed attributes', () => {
+      const sanitized = sanitizeHtml(
+        '<p class="copy" style="color:red" onclick="alert(1)">Safe <strong>text</strong><script>alert(1)</script><img src="x" onerror="alert(1)"></p>'
+      );
+
+      expect(sanitized).toContain('<p class="copy">');
+      expect(sanitized).toContain('<strong>text</strong>');
+      expect(sanitized).not.toMatch(/script|onclick|onerror|style=|<img/i);
+    });
+
+    it('strips dangerous protocols from otherwise allowed links', () => {
+      const sanitized = sanitizeHtml(
+        '<a href="javascript:alert(1)" target="_blank" rel="noopener">Open</a>'
+      );
+
+      expect(sanitized).toContain('>Open</a>');
+      expect(sanitized).not.toMatch(/href|javascript:/i);
+    });
+
+    it('handles empty content', () => {
+      expect(sanitizeHtml('')).toBe('');
+    });
+  });
+
+  describe('escapeHtml', () => {
+    it('escapes markup, ampersands, and both quote types', () => {
+      expect(escapeHtml(`<script>alert("x") & 'y'</script>`)).toBe(
+        '&lt;script&gt;alert(&quot;x&quot;) &amp; &#39;y&#39;&lt;/script&gt;'
+      );
+    });
+
+    it('escapes existing entities instead of interpreting them as markup', () => {
+      expect(escapeHtml('&lt;b&gt;already escaped&lt;/b&gt;')).toBe(
+        '&amp;lt;b&amp;gt;already escaped&amp;lt;/b&amp;gt;'
+      );
+    });
+
+    it('leaves plain text and empty strings unchanged', () => {
+      expect(escapeHtml('Plain text 123')).toBe('Plain text 123');
+      expect(escapeHtml('')).toBe('');
+    });
+  });
+
+  describe('sanitizeUrl', () => {
+    it.each([
+      [
+        'https://example.com/path?q=hello#section',
+        'https://example.com/path?q=hello#section',
+      ],
+      ['http://example.com', 'http://example.com/'],
+      ['HTTPS://EXAMPLE.COM/Docs', 'https://example.com/Docs'],
+    ])('normalizes an allowed URL: %s', (url, expected) => {
+      expect(sanitizeUrl(url)).toBe(expected);
+    });
+
+    it.each([
+      'javascript:alert(1)',
+      'data:text/html,<script>alert(1)</script>',
+      'vbscript:msgbox(1)',
+      'file:///etc/passwd',
+      'mailto:user@example.com',
+      '/relative/path',
+      '//example.com/path',
+      'not a url',
+      '',
+    ])('rejects an unsafe or malformed URL: %s', url => {
+      expect(sanitizeUrl(url)).toBe('#');
+    });
+
+    it('rejects suspicious protocol text embedded in an otherwise valid URL', () => {
+      expect(
+        sanitizeUrl('https://example.com/redirect?next=JaVaScRiPt:alert(1)')
+      ).toBe('#');
+    });
+  });
+
+  describe('validateTool', () => {
+    const validTool = {
+      name: 'Example Tool',
+      url: 'https://example.com',
+      description: 'A useful example.',
+      tags: ['developer', 'free'],
+    };
+
+    it('accepts a complete tool and permits additional metadata', () => {
+      expect(validateTool(validTool)).toBe(true);
+      expect(validateTool({ ...validTool, stars: 42 })).toBe(true);
+    });
+
+    it.each([null, undefined, 'tool', 42, [], {}])(
+      'rejects a non-tool value: %j',
+      tool => {
+        expect(validateTool(tool)).toBe(false);
+      }
+    );
+
+    it.each(['name', 'url', 'description', 'tags'] as const)(
+      'rejects a tool missing %s',
+      field => {
+        const tool = { ...validTool };
+        delete tool[field];
+
+        expect(validateTool(tool)).toBe(false);
+      }
+    );
+
+    const invalidTools: Array<[string, unknown]> = [
+      ['empty name', { ...validTool, name: '' }],
+      ['whitespace-only name', { ...validTool, name: '   ' }],
+      ['non-string name', { ...validTool, name: 123 }],
+      ['empty URL', { ...validTool, url: '' }],
+      ['whitespace-only URL', { ...validTool, url: '   ' }],
+      ['non-string URL', { ...validTool, url: 123 }],
+      ['empty description', { ...validTool, description: '' }],
+      ['whitespace-only description', { ...validTool, description: '   ' }],
+      ['non-string description', { ...validTool, description: 123 }],
+      ['non-array tags', { ...validTool, tags: 'developer' }],
+      ['malformed URL', { ...validTool, url: 'not a url' }],
+    ];
+
+    it.each(invalidTools)('rejects a tool with %s', (_description, tool) => {
+      expect(validateTool(tool)).toBe(false);
+    });
+  });
+
+  describe('getCSPDirectives', () => {
+    it('returns the complete ordered policy', () => {
+      expect(getCSPDirectives().split('; ')).toEqual([
+        "default-src 'self'",
+        "script-src 'self' 'unsafe-inline' https://www.googletagmanager.com",
+        "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
+        "font-src 'self' https://fonts.gstatic.com",
+        "img-src 'self' data: https:",
+        "connect-src 'self' https://www.google-analytics.com",
+        "frame-ancestors 'none'",
+        "base-uri 'self'",
+        "form-action 'self'",
+      ]);
+    });
+  });
+});


### PR DESCRIPTION
## Description

Adds focused unit tests for every export in `src/lib/security.ts`, including allowed and dangerous HTML, escaping edge cases, URL protocol filtering, tool-shape validation, and the generated CSP policy.

The tests exercise the real DOMPurify integration. The existing global Undici override forced jsdom onto incompatible Undici 5 and made `security.ts` impossible to import in Vitest, so this PR adds a narrow `jsdom>undici` override that keeps jsdom on its required Undici 7 while leaving other consumers on the existing compatible version.

This raises `src/lib/security.ts` from 0% to 100% statements, branches, functions, and lines.

## Validation

- [x] `pnpm test --run` — 92 tests passed
- [x] `pnpm test:coverage --run` — `security.ts` at 100% across all metrics
- [x] `pnpm type-check`
- [x] `pnpm lint:check` — 0 errors (existing warnings only)
- [x] `pnpm build`
- [x] Changed files pass Prettier
- [x] Frozen-lockfile install succeeds with pnpm 10.15.0

## Checklist

- [x] Read and understood the [Contributing Guidelines](CONTRIBUTING.md).
- [x] Checked that the changes align with the repository's goals and content.
- [x] The submission is not already present in the list.

## Related Issues

Fixes #273

---

By submitting this pull request, I confirm that I have read and agree to abide by the [Code of Conduct](CODE_OF_CONDUCT.md) and the [Contributing Guidelines](CONTRIBUTING.md) of the AI Tools Collective project.