### PR TITLE
fix: keep PatternStudio controls visible on touch

### DIFF
--- a/src/components/PatternStudio.tsx
+++ b/src/components/PatternStudio.tsx
@@ -553,7 +553,7 @@ const PatternStudio: React.FC = () => {
                             {activeItem?.name === item.id && <div className="w-1.5 h-1.5 rounded-full bg-yellow-500" />}
                             <Trash2 
                                 onClick={(e) => deleteCustomPattern(e, item.id)}
-                                className="w-3 h-3 text-gray-600 hover:text-red-500 opacity-0 group-hover:opacity-100 transition-opacity" 
+                                className="w-6 h-6 p-1.5 shrink-0 cursor-pointer text-gray-600 hover:text-red-500 opacity-60 hover:opacity-100 group-hover:opacity-100 transition-opacity"
                             />
                           </div>
                         </button>
@@ -679,7 +679,7 @@ const PatternStudio: React.FC = () => {
                     
                     {/* Drag Overlay Helper */}
                     {!userInput && !isDragging && (
-                       <div className="absolute inset-0 flex items-center justify-center pointer-events-none opacity-0 group-hover:opacity-100 transition-opacity">
+                       <div className="absolute inset-0 flex items-center justify-center pointer-events-none opacity-60 group-hover:opacity-100 transition-opacity">
                           <div className="text-gray-800 flex flex-col items-center gap-2">
                              <FileText className="w-12 h-12" />
                              <span className="text-xs font-mono">DROP FILES HERE</span>


### PR DESCRIPTION
## Summary
- make the PatternStudio custom-pattern delete icon visible without hover while keeping the stronger hover affordance
- enlarge the delete icon hit area from 12px to 24px for touch use
- make the empty input drop helper visible without requiring hover

## Why
Fixes #270. Touch devices do not have hover, so controls using `opacity-0 group-hover:opacity-100` are effectively invisible before this change.

## Verification
- `npm exec --yes pnpm@10.24.0 -- install --frozen-lockfile`
- `npm exec --yes pnpm@10.24.0 -- run type-check`
- `npm exec --yes pnpm@10.24.0 -- run lint:check` (passes with existing warnings, no errors)
- `npm exec --yes pnpm@10.24.0 -- exec vitest run` (10 files / 49 tests passed)
- `npm exec --yes pnpm@10.24.0 -- run build` (passes; existing CSS optimization warnings remain)
- `git diff --check`
- Mobile smoke check at 390x844 on `/prompt-studio`: injected one local custom pattern, confirmed delete icon is visible at opacity 0.6 with a 24x24 hit area, the drop helper is visible at opacity 0.6, and tapping the delete icon opens the delete confirmation instead of switching panels.

## Notes
- Kept this scoped to `src/components/PatternStudio.tsx`; no dependency or unrelated formatting changes included.
- `pnpm run format:check` currently fails on the repository baseline (99 files reported by Prettier), so I did not run `prettier --write .` or include broad formatting churn in this PR.
- `pnpm audit --audit-level moderate` reports existing dependency advisories (116 total); this PR does not change dependencies.