### PR TITLE
test: cover feature flags and custom patterns

### DIFF
--- a/src/lib/__tests__/customPatternService.test.ts
+++ b/src/lib/__tests__/customPatternService.test.ts
@@ -1,0 +1,130 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { FabricPattern } from '../fabricPatterns';
+import { CustomPatternService } from '../customPatternService';
+
+const STORAGE_KEY = 'FABRIC_CUSTOM_PATTERNS';
+const getItemMock = vi.mocked(localStorage.getItem);
+const setItemMock = vi.mocked(localStorage.setItem);
+
+function createPattern(
+  id: string,
+  overrides: Partial<FabricPattern> = {}
+): FabricPattern {
+  return {
+    id,
+    title: `Pattern ${id}`,
+    description: `Description for ${id}`,
+    systemPrompt: `System prompt for ${id}`,
+    userPromptTemplate: `User prompt for ${id}`,
+    type: 'custom',
+    ...overrides,
+  };
+}
+
+describe('CustomPatternService', () => {
+  beforeEach(() => {
+    getItemMock.mockReset();
+    setItemMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('getPatterns', () => {
+    it('returns an empty list when storage has no custom patterns', () => {
+      getItemMock.mockReturnValue(null);
+
+      expect(CustomPatternService.getPatterns()).toEqual([]);
+      expect(getItemMock).toHaveBeenCalledWith(STORAGE_KEY);
+    });
+
+    it('returns parsed patterns from storage', () => {
+      const patterns = [createPattern('one'), createPattern('two')];
+      getItemMock.mockReturnValue(JSON.stringify(patterns));
+
+      expect(CustomPatternService.getPatterns()).toEqual(patterns);
+    });
+
+    it('logs and returns an empty list for malformed stored JSON', () => {
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      getItemMock.mockReturnValue('{not valid JSON');
+
+      expect(CustomPatternService.getPatterns()).toEqual([]);
+      expect(errorSpy).toHaveBeenCalledWith(
+        'Failed to load custom patterns',
+        expect.any(SyntaxError)
+      );
+    });
+
+    it('logs and returns an empty list when storage cannot be read', () => {
+      const storageError = new Error('storage unavailable');
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      getItemMock.mockImplementation(() => {
+        throw storageError;
+      });
+
+      expect(CustomPatternService.getPatterns()).toEqual([]);
+      expect(errorSpy).toHaveBeenCalledWith(
+        'Failed to load custom patterns',
+        storageError
+      );
+    });
+  });
+
+  describe('savePattern', () => {
+    it('appends a pattern when its ID is not already stored', () => {
+      const existingPattern = createPattern('existing');
+      const newPattern = createPattern('new');
+      getItemMock.mockReturnValue(JSON.stringify([existingPattern]));
+
+      CustomPatternService.savePattern(newPattern);
+
+      expect(setItemMock).toHaveBeenCalledWith(
+        STORAGE_KEY,
+        JSON.stringify([existingPattern, newPattern])
+      );
+    });
+
+    it('replaces an existing pattern with the same ID', () => {
+      const original = createPattern('same');
+      const replacement = createPattern('same', { title: 'Updated title' });
+      const untouched = createPattern('untouched');
+      getItemMock.mockReturnValue(JSON.stringify([original, untouched]));
+
+      CustomPatternService.savePattern(replacement);
+
+      expect(setItemMock).toHaveBeenCalledWith(
+        STORAGE_KEY,
+        JSON.stringify([replacement, untouched])
+      );
+    });
+  });
+
+  describe('deletePattern', () => {
+    it('removes the matching pattern and preserves the others', () => {
+      const removed = createPattern('remove');
+      const kept = createPattern('keep');
+      getItemMock.mockReturnValue(JSON.stringify([removed, kept]));
+
+      CustomPatternService.deletePattern('remove');
+
+      expect(setItemMock).toHaveBeenCalledWith(
+        STORAGE_KEY,
+        JSON.stringify([kept])
+      );
+    });
+
+    it('persists the unchanged list when the ID does not exist', () => {
+      const patterns = [createPattern('one'), createPattern('two')];
+      getItemMock.mockReturnValue(JSON.stringify(patterns));
+
+      CustomPatternService.deletePattern('missing');
+
+      expect(setItemMock).toHaveBeenCalledWith(
+        STORAGE_KEY,
+        JSON.stringify(patterns)
+      );
+    });
+  });
+});

--- a/src/lib/__tests__/featureFlags.test.ts
+++ b/src/lib/__tests__/featureFlags.test.ts
@@ -1,0 +1,127 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  FEATURE_FLAGS,
+  getEnabledFeatures,
+  isFeatureEnabled,
+  updateFeatureFlag,
+} from '../featureFlags';
+
+const originalFlags = structuredClone(FEATURE_FLAGS);
+
+afterEach(() => {
+  for (const flagName of Object.keys(FEATURE_FLAGS)) {
+    delete FEATURE_FLAGS[flagName];
+  }
+  Object.assign(FEATURE_FLAGS, structuredClone(originalFlags));
+  vi.restoreAllMocks();
+});
+
+describe('featureFlags', () => {
+  describe('isFeatureEnabled', () => {
+    it('returns the configured state for ordinary enabled and disabled flags', () => {
+      expect(isFeatureEnabled('DARK_MODE')).toBe(true);
+      expect(isFeatureEnabled('USER_PROFILES')).toBe(false);
+    });
+
+    it('warns and returns false for an unknown flag', () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      expect(isFeatureEnabled('DOES_NOT_EXIST')).toBe(false);
+      expect(warnSpy).toHaveBeenCalledWith(
+        "Feature flag 'DOES_NOT_EXIST' not found"
+      );
+    });
+
+    it('uses a deterministic user hash for percentage rollouts', () => {
+      FEATURE_FLAGS.ROLLOUT_TEST = {
+        name: 'rollout_test',
+        enabled: true,
+        description: 'Test percentage rollout',
+        rolloutPercentage: 50,
+      };
+
+      expect(isFeatureEnabled('ROLLOUT_TEST', 'user-a')).toBe(true);
+      expect(isFeatureEnabled('ROLLOUT_TEST', 'user-b')).toBe(false);
+      expect(isFeatureEnabled('ROLLOUT_TEST', 'user-a')).toBe(true);
+    });
+
+    it('limits a targeted flag to listed users when a user ID is supplied', () => {
+      FEATURE_FLAGS.TARGETED_TEST = {
+        name: 'targeted_test',
+        enabled: true,
+        description: 'Test targeted rollout',
+        targetUsers: ['included-user'],
+      };
+
+      expect(isFeatureEnabled('TARGETED_TEST', 'included-user')).toBe(true);
+      expect(isFeatureEnabled('TARGETED_TEST', 'other-user')).toBe(false);
+    });
+
+    it('falls back to the configured state when no user ID is supplied', () => {
+      FEATURE_FLAGS.TARGETED_TEST = {
+        name: 'targeted_test',
+        enabled: true,
+        description: 'Test targeted rollout',
+        targetUsers: ['included-user'],
+      };
+
+      expect(isFeatureEnabled('TARGETED_TEST')).toBe(true);
+    });
+
+    it('never enables a disabled flag through rollout rules', () => {
+      FEATURE_FLAGS.DISABLED_TEST = {
+        name: 'disabled_test',
+        enabled: false,
+        description: 'Test disabled rollout',
+        rolloutPercentage: 100,
+        targetUsers: ['included-user'],
+      };
+
+      expect(isFeatureEnabled('DISABLED_TEST', 'included-user')).toBe(false);
+    });
+  });
+
+  describe('getEnabledFeatures', () => {
+    it('lists only enabled feature keys', () => {
+      expect(getEnabledFeatures()).toEqual([
+        'DARK_MODE',
+        'ADVANCED_SEARCH',
+        'VIRTUAL_SCROLLING',
+        'LAZY_LOADING',
+        'CLICK_TRACKING',
+      ]);
+    });
+
+    it('reflects runtime flag updates', () => {
+      updateFeatureFlag('TOOL_RATINGS', { enabled: true });
+
+      expect(getEnabledFeatures()).toContain('TOOL_RATINGS');
+    });
+  });
+
+  describe('updateFeatureFlag', () => {
+    it('merges partial updates into an existing flag', () => {
+      updateFeatureFlag('DARK_MODE', {
+        enabled: false,
+        description: 'Temporarily disabled',
+        targetUsers: ['admin'],
+      });
+
+      expect(FEATURE_FLAGS.DARK_MODE).toEqual({
+        name: 'dark_mode',
+        enabled: false,
+        description: 'Temporarily disabled',
+        targetUsers: ['admin'],
+      });
+    });
+
+    it('ignores updates for an unknown flag', () => {
+      updateFeatureFlag('DOES_NOT_EXIST', {
+        enabled: true,
+        description: 'Should not be created',
+      });
+
+      expect(FEATURE_FLAGS).not.toHaveProperty('DOES_NOT_EXIST');
+    });
+  });
+});


### PR DESCRIPTION
## Description

Adds focused unit tests for every exported behavior in `src/lib/featureFlags.ts` and `src/lib/customPatternService.ts` without changing production code.

The feature-flag tests cover enabled, disabled, and unknown flags; deterministic percentage rollouts; targeted users; runtime updates; enabled-feature discovery; and state isolation between cases. The custom-pattern tests cover empty, valid, malformed, and unavailable local storage; inserting and replacing patterns; and deletion behavior.

Both target modules increase from 0% to 100% statements, branches, functions, and lines.

## Validation

- [x] `pnpm test --run` — 67 tests passed
- [x] `pnpm test:coverage --run` — both target modules at 100% across all metrics
- [x] `pnpm type-check`
- [x] `pnpm lint:check` — 0 errors (existing warnings only)
- [x] `pnpm build`
- [x] Changed files pass Prettier

## Checklist

- [x] Read and understood the [Contributing Guidelines](CONTRIBUTING.md).
- [x] Checked that the changes align with the repository's goals and content.
- [x] The submission is not already present in the list.

## Related Issues

Fixes #274

---

By submitting this pull request, I confirm that I have read and agree to abide by the [Code of Conduct](CODE_OF_CONDUCT.md) and the [Contributing Guidelines](CONTRIBUTING.md) of the AI Tools Collective project.