### PR TITLE
fix: keep compact card arrows visible on touch

### DIFF
--- a/src/components/tools/CompactToolCard.test.tsx
+++ b/src/components/tools/CompactToolCard.test.tsx
@@ -1,0 +1,24 @@
+import { render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import CompactToolCard from './CompactToolCard';
+import type { Tool } from '../../types/tools';
+
+const tool: Tool = {
+  name: 'Example Tool',
+  url: 'https://example.com',
+  description: 'An example tool for testing.',
+  tags: ['testing'],
+};
+
+describe('CompactToolCard', () => {
+  it('keeps the external-link affordance visible without hover', () => {
+    const { container } = render(
+      <CompactToolCard tool={tool} rank={1} onTrackClick={vi.fn()} />
+    );
+
+    const arrow = container.querySelector('svg')?.parentElement;
+
+    expect(arrow).toHaveClass('opacity-60', 'group-hover:opacity-100');
+    expect(arrow).not.toHaveClass('opacity-0');
+  });
+});

--- a/src/components/tools/CompactToolCard.tsx
+++ b/src/components/tools/CompactToolCard.tsx
@@ -68,7 +68,7 @@ const CompactToolCard: React.FC<CompactToolCardProps> = ({ tool, rank, onTrackCl
         </div>
       </div>
       
-      <div className="absolute top-1/2 -translate-y-1/2 right-4 opacity-0 group-hover:opacity-100 transition-all duration-300 transform translate-x-2 group-hover:translate-x-0">
+      <div className="absolute top-1/2 -translate-y-1/2 right-4 opacity-60 group-hover:opacity-100 transition-all duration-300 transform translate-x-2 group-hover:translate-x-0">
         <ExternalLink className="h-4 w-4 text-gray-400 dark:text-gray-300" />
       </div>
     </a>


### PR DESCRIPTION
## Description

Compact tool cards currently hide their trailing external-link arrow behind
`opacity-0`, so touch users never see the affordance that signals the whole
card is actionable.

This change:

- keeps the arrow visible at `opacity-60` without requiring hover
- preserves the existing desktop hover transition to full opacity
- adds a focused regression test that prevents the arrow from returning to
  `opacity-0`

## Checklist

- [x] Read and understood the [Contributing Guidelines](CONTRIBUTING.md).
- [x] Checked that the changes align with the repository's goals and content.
- [x] Confirmed there is no existing PR for this issue.

## Related Issues

Fixes #271

## Testing

- `pnpm exec vitest run src/components/tools/CompactToolCard.test.tsx`
- `pnpm test -- --run` - 50 tests passed
- `pnpm type-check`
- `pnpm lint:check` - 0 errors (existing repository warnings remain)
- `pnpm build` - successful (existing CSS optimization warnings remain)
- Playwright at a 390 x 844 touch viewport: all four rendered compact-card
  arrows were visible, inside their cards, with computed opacity `0.6`
