### PR TITLE
refactor: type admin resource components

### DIFF
--- a/src/components/admin/resources/AdminAITools.tsx
+++ b/src/components/admin/resources/AdminAITools.tsx
@@ -1,12 +1,22 @@
 import { useEffect, useState } from 'react';
 import AdminDataTable from '../AdminDataTable';
 import { ExternalLink } from 'lucide-react';
+import type {
+  AdminAITool,
+  AdminListParams,
+  AdminListResponse
+} from './types';
 
 export default function AdminAITools() {
-  const [data, setData] = useState([]);
+  const [data, setData] = useState<AdminAITool[]>([]);
   const [pagination, setPagination] = useState({ page: 1, limit: 10, total: 0, pages: 0 });
   const [loading, setLoading] = useState(true);
-  const [params, setParams] = useState({ page: 1, search: '', sortBy: 'createdAt', order: 'desc' });
+  const [params, setParams] = useState<AdminListParams>({
+    page: 1,
+    search: '',
+    sortBy: 'createdAt',
+    order: 'desc'
+  });
 
   useEffect(() => {
     fetchData();
@@ -23,7 +33,7 @@ export default function AdminAITools() {
         order: params.order
       });
       const res = await fetch(`/api/admin/ai-tools?${query}`);
-      const result = await res.json();
+      const result: AdminListResponse<AdminAITool> = await res.json();
       setData(result.data);
       setPagination(result.pagination);
     } catch (error) {
@@ -35,13 +45,20 @@ export default function AdminAITools() {
 
   const columns = [
     { key: 'name', label: 'Name', sortable: true },
-    { key: 'description', label: 'Description', render: (row: any) => <span className="line-clamp-1" title={row.description}>{row.description}</span> },
-    { key: 'url', label: 'Link', render: (row: any) => (
+    { key: 'description', label: 'Description', render: (row: AdminAITool) => (
+      <span className="line-clamp-1" title={row.description}>{row.description}</span>
+    )},
+    { key: 'url', label: 'Link', render: (row: AdminAITool) => (
         <a href={row.url} target="_blank" rel="noopener noreferrer" className="text-blue-600 hover:text-blue-500">
             <ExternalLink className="h-4 w-4" />
         </a>
     )},
-    { key: 'addedDate', label: 'Added', sortable: true, render: (row: any) => new Date(row.addedDate).toLocaleDateString() }
+    {
+      key: 'addedDate',
+      label: 'Added',
+      sortable: true,
+      render: (row: AdminAITool) => new Date(row.addedDate).toLocaleDateString()
+    }
   ];
 
   return (

--- a/src/components/admin/resources/AdminMCPClients.tsx
+++ b/src/components/admin/resources/AdminMCPClients.tsx
@@ -1,12 +1,22 @@
 import { useEffect, useState } from 'react';
 import AdminDataTable from '../AdminDataTable';
 import { ExternalLink } from 'lucide-react';
+import type {
+  AdminListParams,
+  AdminListResponse,
+  AdminMCPResource
+} from './types';
 
 export default function AdminMCPClients() {
-  const [data, setData] = useState([]);
+  const [data, setData] = useState<AdminMCPResource[]>([]);
   const [pagination, setPagination] = useState({ page: 1, limit: 10, total: 0, pages: 0 });
   const [loading, setLoading] = useState(true);
-  const [params, setParams] = useState({ page: 1, search: '', sortBy: 'createdAt', order: 'desc' });
+  const [params, setParams] = useState<AdminListParams>({
+    page: 1,
+    search: '',
+    sortBy: 'createdAt',
+    order: 'desc'
+  });
 
   useEffect(() => {
     fetchData();
@@ -23,7 +33,7 @@ export default function AdminMCPClients() {
         order: params.order
       });
       const res = await fetch(`/api/admin/mcp-clients?${query}`);
-      const result = await res.json();
+      const result: AdminListResponse<AdminMCPResource> = await res.json();
       setData(result.data);
       setPagination(result.pagination);
     } catch (error) {
@@ -35,13 +45,20 @@ export default function AdminMCPClients() {
 
   const columns = [
     { key: 'name', label: 'Name', sortable: true },
-    { key: 'description', label: 'Description', render: (row: any) => <span className="line-clamp-1" title={row.description}>{row.description}</span> },
-    { key: 'url', label: 'Link', render: (row: any) => (
+    { key: 'description', label: 'Description', render: (row: AdminMCPResource) => (
+      <span className="line-clamp-1" title={row.description}>{row.description}</span>
+    )},
+    { key: 'url', label: 'Link', render: (row: AdminMCPResource) => (
         <a href={row.url} target="_blank" rel="noopener noreferrer" className="text-blue-600 hover:text-blue-500">
             <ExternalLink className="h-4 w-4" />
         </a>
     )},
-    { key: 'addedDate', label: 'Added', sortable: true, render: (row: any) => new Date(row.addedDate).toLocaleDateString() }
+    {
+      key: 'addedDate',
+      label: 'Added',
+      sortable: true,
+      render: (row: AdminMCPResource) => new Date(row.addedDate).toLocaleDateString()
+    }
   ];
 
   return (

--- a/src/components/admin/resources/AdminMCPServers.tsx
+++ b/src/components/admin/resources/AdminMCPServers.tsx
@@ -1,12 +1,22 @@
 import { useEffect, useState } from 'react';
 import AdminDataTable from '../AdminDataTable';
 import { ExternalLink } from 'lucide-react';
+import type {
+  AdminListParams,
+  AdminListResponse,
+  AdminMCPResource
+} from './types';
 
 export default function AdminMCPServers() {
-  const [data, setData] = useState([]);
+  const [data, setData] = useState<AdminMCPResource[]>([]);
   const [pagination, setPagination] = useState({ page: 1, limit: 10, total: 0, pages: 0 });
   const [loading, setLoading] = useState(true);
-  const [params, setParams] = useState({ page: 1, search: '', sortBy: 'createdAt', order: 'desc' });
+  const [params, setParams] = useState<AdminListParams>({
+    page: 1,
+    search: '',
+    sortBy: 'createdAt',
+    order: 'desc'
+  });
 
   useEffect(() => {
     fetchData();
@@ -23,7 +33,7 @@ export default function AdminMCPServers() {
         order: params.order
       });
       const res = await fetch(`/api/admin/mcp-servers?${query}`);
-      const result = await res.json();
+      const result: AdminListResponse<AdminMCPResource> = await res.json();
       setData(result.data);
       setPagination(result.pagination);
     } catch (error) {
@@ -35,13 +45,20 @@ export default function AdminMCPServers() {
 
   const columns = [
     { key: 'name', label: 'Name', sortable: true },
-    { key: 'description', label: 'Description', render: (row: any) => <span className="line-clamp-1" title={row.description}>{row.description}</span> },
-    { key: 'url', label: 'Link', render: (row: any) => (
+    { key: 'description', label: 'Description', render: (row: AdminMCPResource) => (
+      <span className="line-clamp-1" title={row.description}>{row.description}</span>
+    )},
+    { key: 'url', label: 'Link', render: (row: AdminMCPResource) => (
         <a href={row.url} target="_blank" rel="noopener noreferrer" className="text-blue-600 hover:text-blue-500">
             <ExternalLink className="h-4 w-4" />
         </a>
     )},
-    { key: 'addedDate', label: 'Added', sortable: true, render: (row: any) => new Date(row.addedDate).toLocaleDateString() }
+    {
+      key: 'addedDate',
+      label: 'Added',
+      sortable: true,
+      render: (row: AdminMCPResource) => new Date(row.addedDate).toLocaleDateString()
+    }
   ];
 
   return (

--- a/src/components/admin/resources/types.ts
+++ b/src/components/admin/resources/types.ts
@@ -1,0 +1,23 @@
+import type { AITool, MCPServer } from '@/lib/api';
+
+export type AdminAITool = AITool & Required<Pick<AITool, 'addedDate'>>;
+
+export type AdminMCPResource = MCPServer &
+  Required<Pick<MCPServer, 'url' | 'addedDate'>>;
+
+export interface AdminListResponse<T> {
+  data: T[];
+  pagination: {
+    page: number;
+    limit: number;
+    total: number;
+    pages: number;
+  };
+}
+
+export interface AdminListParams {
+  page: number;
+  search: string;
+  sortBy: string;
+  order: 'asc' | 'desc';
+}


### PR DESCRIPTION
## Description

Removes the unsafe `any` annotations from the AI Tools, MCP Clients, and MCP Servers admin resource tables without changing runtime behavior.

The three components now reuse the existing `AITool` and `MCPServer` domain types, with a small type-only helper that defines the admin endpoint's pagination/query contract and marks the fields these tables require. State, API results, sort order, and column render callbacks are now explicitly typed.

This focused slice removes all 9 `no-explicit-any` warnings from the claimed files and reduces repository lint warnings from 97 to 88. Other admin components remain available for separate follow-up PRs.

## Validation

- [x] Focused ESLint — 0 `no-explicit-any` warnings in the claimed files
- [x] `pnpm lint:check` — 0 errors; total warnings reduced from 97 to 88
- [x] `pnpm type-check`
- [x] `pnpm test --run` — 49 tests passed
- [x] `pnpm build`
- [x] Frozen-lockfile install succeeds with pnpm 10.15.0
- [x] New shared type file passes Prettier

## Checklist

- [x] Read and understood the [Contributing Guidelines](CONTRIBUTING.md).
- [x] Checked that the changes align with the repository's goals and content.
- [x] The submission is not already present in the list.

## Related Issues

Part of #269

---

By submitting this pull request, I confirm that I have read and agree to abide by the [Code of Conduct](CODE_OF_CONDUCT.md) and the [Contributing Guidelines](CONTRIBUTING.md) of the AI Tools Collective project.