### PR TITLE
Add YingTu to developer tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -487,7 +487,7 @@ Use these hashtags in search to filter out the tools
 - [Warp](https://www.warp.dev/) - Parallel agent operation for fast completion. `#paid`
 - [Windsurf](https://codeium.com/windsurf) - AI-powered IDE with built-in code generation and chat `#freemium`
 - [Windsurf (Codeium)](https://codeium.com/windsurf)%20AI%20Tool) - Multi-step collaborative Cascade technology. `#free`
-- [YingTu](https://yingtu.ai/en) - Browser playground for testing AI image and video API routes, prompts, reference inputs, task status, and downloads before integration. `#developer` `#image`
+- [YingTu](https://yingtu.ai/en) - Browser playground for testing AI image and video API routes, prompts, reference inputs, task status, and downloads before integration. `#free`
 
 **[⬆️ Back to Top](#table-of-contents)**
 

--- a/README.md
+++ b/README.md
@@ -487,6 +487,7 @@ Use these hashtags in search to filter out the tools
 - [Warp](https://www.warp.dev/) - Parallel agent operation for fast completion. `#paid`
 - [Windsurf](https://codeium.com/windsurf) - AI-powered IDE with built-in code generation and chat `#freemium`
 - [Windsurf (Codeium)](https://codeium.com/windsurf)%20AI%20Tool) - Multi-step collaborative Cascade technology. `#free`
+- [YingTu](https://yingtu.ai/en) - Browser playground for testing AI image and video API routes, prompts, reference inputs, task status, and downloads before integration. `#developer` `#image`
 
 **[⬆️ Back to Top](#table-of-contents)**
 


### PR DESCRIPTION
## Description

Adds YingTu to the Developer Tools section using the canonical product URL and the non-pricing tags `#developer` and `#image`.

YingTu is a browser playground for testing AI image and video API routes, prompts, reference inputs, task status, and downloads before integration.

Submitted on behalf of YingTu with Codex assistance.

## Checklist

- [x] Read and understood the [Contributing Guidelines](CONTRIBUTING.md).
- [x] Checked that the change aligns with the repository's goals and content.
- [x] Confirmed that YingTu and yingtu.ai are not already present in the list.

## Related Issues

None.

## Additional Notes

This changes exactly one README line and does not modify unrelated entries. I have read and agree to the [Code of Conduct](CODE_OF_CONDUCT.md) and the [Contributing Guidelines](CONTRIBUTING.md).