### PR TITLE
feat: Add videos.social to Video

### DIFF
--- a/README.md
+++ b/README.md
@@ -1195,6 +1195,7 @@ Use these hashtags in search to filter out the tools
 - [Veed Background](https://www.veed.io/tools/background-remover) - Online background removal and green-screen. `#free`
 - [Veo](https://deepmind.google/models/veo/) - Google DeepMind's text-to-video model (currently Veo 3.1), generates cinematic video with synchronized audio and realistic physics. `#paid`
 - [Video Ocean](https://videoocean.com/) - Text-to-video scene simulation platform. `#free`
+- [videos.social](https://videos.social/?utm_source=collective-ai-tools&utm_medium=directory&utm_campaign=listing-wave-d) - Turns blogs, PDFs, and prompts into editable faceless videos. 1 free render. Packs from $10. 1 credit = 1 render. `#freemium`
 - [VidLux AI](https://vidlux.ai/) - An all-in-one AI video creation platform for generating and editing videos from text, images, videos, and audio references. `#freemium`
 - [Vidnoz](https://www.vidnoz.com/) - Use Vidnoz AI and Vidnoz Flex to make winning videos! `#freemium`
 - [Vidu](https://www.vidu.studio/) - Long-duration video large model (Tsinghua). `#free`

--- a/README.md
+++ b/README.md
@@ -1195,7 +1195,7 @@ Use these hashtags in search to filter out the tools
 - [Veed Background](https://www.veed.io/tools/background-remover) - Online background removal and green-screen. `#free`
 - [Veo](https://deepmind.google/models/veo/) - Google DeepMind's text-to-video model (currently Veo 3.1), generates cinematic video with synchronized audio and realistic physics. `#paid`
 - [Video Ocean](https://videoocean.com/) - Text-to-video scene simulation platform. `#free`
-- [videos.social](https://videos.social/?utm_source=collective-ai-tools&utm_medium=directory&utm_campaign=listing-wave-d) - Turns blogs, PDFs, and prompts into editable faceless videos. 1 free render. Packs from $10. 1 credit = 1 render. `#freemium`
+- [videos.social](https://videos.social/) - Turns blogs, PDFs, and prompts into editable faceless videos. 1 free render. Packs from $10. 1 credit = 1 render. `#freemium`
 - [VidLux AI](https://vidlux.ai/) - An all-in-one AI video creation platform for generating and editing videos from text, images, videos, and audio references. `#freemium`
 - [Vidnoz](https://www.vidnoz.com/) - Use Vidnoz AI and Vidnoz Flex to make winning videos! `#freemium`
 - [Vidu](https://www.vidu.studio/) - Long-duration video large model (Tsinghua). `#free`


### PR DESCRIPTION
Adds videos.social under **Video**, alphabetically after Video Ocean (next to Pictory / Fliki / InVideo / Faceless Reels).

videos.social turns blogs, PDFs, and prompts into editable faceless videos (script, scenes, voiceover) rather than a locked regenerate loop. Start free — 1 render included. Packs from $10. 1 credit = 1 render.

Public, usable product in the same class as Pictory / Fliki. Not a duplicate.

Entry:

- [videos.social](https://videos.social/?utm_source=collective-ai-tools&utm_medium=directory&utm_campaign=listing-wave-d) - Turns blogs, PDFs, and prompts into editable faceless videos. 1 free render. Packs from $10. 1 credit = 1 render. `#freemium`

Disclosure: submitted by the videos.social team.