### PR TITLE
Add AI TikTok Analyzer Pro to Marketing

### DIFF
--- a/README.md
+++ b/README.md
@@ -815,6 +815,7 @@ Use these hashtags in search to filter out the tools
 
 ## Marketing
 
+- [AI TikTok Analyzer Pro](https://tiktok.poviai.com/) - Research public TikTok content: rank a creator's videos by plays, likes or comments, export comment threads to Excel or CSV, and generate AI transcripts with 9-language translation. `#freemium`
 - [Clay](https://www.clay.com/) - Automates outreach and contact workflows (cold email, LinkedIn DMs) based on buyer personas. `#freemium`
 - [Elaris by Solsten](https://elaris.new/) - Understand audience psychology and get actionable insights for marketing and product decisions. `#paid`
 - [HighReach](https://highreach.ai/) - Generates platform-ready video, image, and UGC ad creatives from product URLs for Meta, TikTok, and Google. `#paid`


### PR DESCRIPTION
Adds one entry to `## Marketing`, placed alphabetically at the top of the section.

**What it is:** a browser extension plus a web workbench for researching public TikTok content — ranking a creator's public videos by plays, likes or comments; exporting comment threads to Excel or CSV with timestamps and reply nesting; AI transcription for videos that have no captions; and translation across 9 languages.

**Why here:** the section already covers TikTok-adjacent marketing tooling (TikTokalyzer for analytics, HighReach for TikTok ad creative). This one sits on the research side — getting the text out of a profile, comments and spoken audio, in a language the marketer reads. TikTok's own interface exports neither comments nor transcripts, so it fills a gap rather than duplicating an existing entry.

**Checklist from CONTRIBUTING.md:**
- Format matches: `- [Tool Name](url) - one-sentence description. \`#tag\``
- URL is a direct link to the tool, not an article or blog post — https://tiktok.poviai.com/ returns 200.
- Tagged `#freemium` (free quota, then paid tiers).
- Not already in the list — searched the README for the name and the domain, no match.
- Alphabetical placement within the section.

**Scope note:** it analyzes public content and does not provide GMV or sales data — flagging that so the description doesn't oversell.

**Disclosure:** I work on this tool. Happy to shorten the description or move the entry if you'd prefer a different spot.