### PR TITLE
Add DressMeAI to Fashion

### DIFF
--- a/README.md
+++ b/README.md
@@ -593,6 +593,7 @@ Use these hashtags in search to filter out the tools
 
 ## Fashion
 
+- [DressMeAI](https://dressmeai.com/) - AI virtual try-on from a person photo and clothing image. `#paid`
 - [Dressrious](https://www.dressrious.com/) - Offers personalized daily outfit recommendations based on users' wardrobe items, weather conditions, occasions, and color preferences. `#free`
 - [Intelistyle](https://www.intelistyle.com/) -  offers personalized styling and virtual try-on features for a better online shopping experience. `#paid`
 - [Zyler](https://business.zyler.com/) - Enables customers to virtually try on clothes, offering a personalized shopping experience. `#paid`


### PR DESCRIPTION
## Description

Adds DressMeAI to the Fashion category. It provides AI virtual try-on by combining a person photo with a clothing image.

I am connected to the product and am submitting it transparently. The link points directly to the official product, the description is factual, and the pricing tag is `#paid`.

## Type of Change

- [x] Tool Submission

## Checklist

- [x] I checked that the tool is not already listed
- [x] The URL is live and points directly to the tool
- [x] The entry follows the category format and alphabetical order
- [x] I performed a self-review